### PR TITLE
商品削除機能　実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show, :destroy]
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -23,6 +23,8 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
+    return unless item.user == current_user
+
     item.destroy
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def destory
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -138,7 +138,7 @@
           <%= image_tag item.image , class: "item-img" %>
          
           
-          <% if item.id == nil%>
+          <% if @items.any? == false  %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -105,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
      <% if user_signed_in? && current_user == @item.user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
    <% end %>
 
    <% if user_signed_in? && @item.user != current_user %>


### PR DESCRIPTION
#WHAT
削除機能を追加

#WHY
投稿者が投稿をを削除するため


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/d83b8271f2ad3684ae5ddf87c912d148